### PR TITLE
Update README.md to add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,14 @@ This app illustrates the following functionality amongst other components:
     * `Check_if_Registry_key_Value_Exist.yml`: Workflow to invoke the `Check_Registry_Exist` RTR script against a collection of hosts.  Results are written to LogScale.
     * `Notify_status.yml`: Workflow which notifies the `job_history` function to report results of the `Check_if_files_or_registry_key_exist` and `Check_if_Registry_key_Value_Exist.yml`.
 
-## Deploying and installing the app
+## Running, deploying and installing the app
 
-For detailed info about deploying and installing this app in your CID, see the Falcon Foundry product documentation:
+For detailed info about running, deploying and installing this app in your CID, see the Falcon Foundry product documentation:
 
+* Overview and setup
+    * US-1: [Before you begin](https://falcon.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities)
+    * US-2: [Before you begin](https://falcon.us-2.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities)
+    * EU-1: [Before you begin](https://falcon.eu-1.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities)
 * Deploy an app
     * US-1: [Deploy an app](https://falcon.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app)
     * US-2: [Deploy an app](https://falcon.us-2.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app)


### PR DESCRIPTION
A new user coming to this repo to see an example of a Foundry application for the first time won't necessarily know how to install the CLI or run the application locally.

This commit adds links to the relevant section in the documentation so that users perform those initial steps before deploying applications.