### PR TITLE
Improve README so it's more useful to developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ You should be able to create a job and save it. After the job executes, you'll r
 
 * **Collections.** Used by the app to store state information, such as metadata about created jobs, execution history, and an audit log.
 * **Functions.** Backend business logic for invoking workflows, normalizing and aggregating data to be returned to the UI, and modifying the state of the collections.
-* **LogScale queries.** Query results of RTR script execution to extract metadata about on which hosts the scripts successfully executed.
+* **Queries.** Query results of RTR script execution to extract metadata about on which hosts the scripts successfully executed.
 * **RTR scripts.** Verifies files and registry keys on a target system.
 * **UI navigation.** Adds the app to the Falcon navigation for easy access.
 * **UI pages.** Custom UI pages to display results and manage the app.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This app illustrates the following functionality amongst other components:
 
 * Foundry CLI (instructions below)
 * Go v1.21+ (needed if modifying the app's functions). See https://go.dev/learn for installation instructions.
-* YARN (needed if modifying the app's UI). See https://yarnpkg.com/getting-started for installation instructions.
+* Yarn (needed if modifying the app's UI). See https://yarnpkg.com/getting-started for installation instructions.
 
 ### Install the Foundry CLI
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Select the following permissions:
 Deploy it to Foundry:
 
 ```shell
-foundry deploy
+foundry apps deploy
 ```
 
 > [!TIP]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This app is one of several App Templates included in Foundry that you can use to
 preconfigured capabilities aligned to its business purpose. Deploy this app from the Templates page with a single click in the Foundry UI, or 
 create an app from this template using the CLI.
 
-Please complete the Foundry Quickstart before deploying this sample. You can find it in Falcon under **Foundry** > **Learn** ([US-1](https://falcon.crowdstrike.com/foundry/learn) | [US-2](https://falcon.us-2.crowdstrike.com/foundry/learn) | [EU](https://falcon.eu-1.crowdstrike.com/foundry/learn)). 
+Please complete the Foundry Quickstart before deploying this sample. You can find it in Falcon under **Foundry** > **Learn**: [US-1](https://falcon.crowdstrike.com/foundry/learn) | [US-2](https://falcon.us-2.crowdstrike.com/foundry/learn) | [EU](https://falcon.eu-1.crowdstrike.com/foundry/learn). 
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Select the following permissions:
 - [x] Run, execute, and test LogScale queries
 - [ ] (optional) Generate mock data to test your app
 
-Deploy the app to Foundry:
+Deploy the app:
 
 ```shell
 foundry apps deploy

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Run `foundry version` to verify it's installed correctly.
 Clone this sample to your local system, or [download as a zip file](https://github.com/CrowdStrike/foundry-sample-scalable-rtr/archive/refs/heads/main.zip).
 
 ```shell
-git clone https://github.com/mraible/foundry-sample-scalable-rtr
+git clone https://github.com/CrowdStrike/foundry-sample-scalable-rtr
 cd foundry-sample-scalable-rtr
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Next, go to **Foundry** > **App catalog**, find your app, and install it. Select
 > [!TIP]
 > If the app doesn't load, reload the page.
 
-You should be able to enter a job. After the job executes, you'll receive an email with the execution information.
+You should be able to create a job and save it. After the job executes, you'll receive an email with the execution information.
 
 ## About this sample app
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Please complete the Foundry Quickstart before deploying this sample. You can fin
 ## Description
 
 The Scalable RTR sample Foundry app provides a way to orchestrate the verification of files and registry keys
-across Windows-based systems, either by targeting specifying specific hosts or by targeting the host groups.
+across Windows-based systems, either by targeting specific hosts or by targeting the host groups.
 
 This app illustrates the following functionality amongst other components:
-* use of LogScale saved searches
+* use of saved searches
 * use of RTR script orchestration via workflows, including scheduling and recurrence
 * use of UI components and extensions
 * use of functions
@@ -105,7 +105,7 @@ You should be able to create a job and save it. After the job executes, you'll r
 
 * **Collections.** Used by the app to store state information, such as metadata about created jobs, execution history, and an audit log.
 * **Functions.** Backend business logic for invoking workflows, normalizing and aggregating data to be returned to the UI, and modifying the state of the collections.
-* **LogScale queries.** Query results of RTR script execution from LogScale to extract metadata about on which hosts the scripts successfully executed.
+* **LogScale queries.** Query results of RTR script execution to extract metadata about on which hosts the scripts successfully executed.
 * **RTR scripts.** Verifies files and registry keys on a target system.
 * **UI navigation.** Adds the app to the Falcon navigation for easy access.
 * **UI pages.** Custom UI pages to display results and manage the app.
@@ -130,8 +130,8 @@ You should be able to create a job and save it. After the job executes, you'll r
     * `job_history`: Manages the job execution history.
 * `rtr-scripts`
     * `check_file_or_registry_exist`: RTR script which checks if a file or registry key is present on a Windows system.
-    * `Check_Registry_Exist`: RTR script which checks if a registry key with a specific value is present on Windows system.
-* `saved-searches/Query_By_WorkflowRootExecutionID`: LogScale saved search for retrieving events by a workflow execution ID.
+    * `Check_Registry_Exist`: RTR script which checks if a registry key with a specific value is present on a Windows system.
+* `saved-searches/Query_By_WorkflowRootExecutionID`: Saved search for retrieving events by a workflow execution ID.
 * `ui/pages/scalable-rtr-react`: Single Page Application which serves as the frontend of the app.
 * `workflows`: Workflow template definitions. Fusion workflows are created from the templates in this directory.
     * `Check_if_files_or_registry_key_exist.yml`: Workflow to invoke the `check_file_or_registry_exist` RTR script against a collection of hosts. Results are written to LogScale.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ This app illustrates the following functionality amongst other components:
 ## Prerequisites
 
 * Foundry CLI (instructions below)
-* Go v1.21+ (needed if modifying functions). See https://go.dev/learn/ for instructions to install.
-* YARN (needed if modifying UI). See https://yarnpkg.com/getting-started for instructions to install.
+* Go v1.21+ (needed if modifying the app's functions). See https://go.dev/learn for installation instructions.
+* YARN (needed if modifying the app's UI). See https://yarnpkg.com/getting-started for installation instructions.
 
 ### Install the Foundry CLI
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ git clone https://github.com/CrowdStrike/foundry-sample-scalable-rtr
 cd foundry-sample-scalable-rtr
 ```
 
-Log in to your Foundry instance:
+Log in to Foundry:
 
 ```shell
 foundry login

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ foundry apps deploy
 
 Once the deployment has finished, release the app using the three-dot menu on the right. Next, go to **Foundry** > **App catalog**, find your app, and install it.
 
-Then, open the main menu in the top left and go to **Custom Apps**. You should see your app listed and be able to enter a job. After the job executes, you'll receive an email with the execution information.
+Go to **Custom apps**. You should see your app listed and be able to enter a job. After the job executes, you'll receive an email with the execution information.
 
 ## Basic information
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This app is one of several App Templates included in Foundry that you can use to
 preconfigured capabilities aligned to its business purpose. Deploy this app from the Templates page with a single click in the Foundry UI, or 
 create an app from this template using the CLI.
 
-Please complete the Foundry Quickstart before deploying this sample. You can find it in Falcon under Foundry > Learn ([US](https://falcon.crowdstrike.com/foundry/learn), [US-2](https://falcon.us-2.crowdstrike.com/foundry/learn), [EU](https://falcon.eu-1.crowdstrike.com/foundry/learn)). 
+Please complete the Foundry Quickstart before deploying this sample. You can find it in Falcon under **Foundry** > **Learn** ([US](https://falcon.crowdstrike.com/foundry/learn), [US-2](https://falcon.us-2.crowdstrike.com/foundry/learn), [EU](https://falcon.eu-1.crowdstrike.com/foundry/learn)). 
 
 ## Description
 
@@ -22,17 +22,15 @@ This app illustrates the following functionality amongst other components:
 * use of UI components and extensions
 * use of functions
 
-## Basic information
-
-### Dependencies
+## Prerequisites
 
 * Foundry CLI (instructions below)
 * Go v1.21+ (needed if modifying functions). See https://go.dev/learn/ for instructions to install.
 * YARN (needed if modifying UI). See https://yarnpkg.com/getting-started for instructions to install.
 
-#### Install the Foundry CLI 
+### Install the Foundry CLI
 
-You can install the Foundry CLI with Scoop on Windows or Homebrew on Linux/macOS. 
+You can install the Foundry CLI with Scoop on Windows or Homebrew on Linux/macOS.
 
 **Windows**:
 
@@ -55,6 +53,44 @@ brew install foundry
 ```
 
 Run `foundry version` to verify it's installed correctly.
+
+## Getting Started
+
+Clone this sample to your local system, or [download as a zip file](https://github.com/CrowdStrike/foundry-sample-scalable-rtr/archive/refs/heads/main.zip).
+
+```shell
+git clone https://github.com/mraible/foundry-sample-scalable-rtr
+cd foundry-sample-scalable-rtr
+```
+
+Log in to your Foundry instance:
+
+```shell
+foundry login
+```
+
+Select the following permissions:
+
+- [x] Run RTR Scripts
+- [x] Run, execute, and test Workflows
+- [x] Run, execute, and test API integrations
+- [x] Run, execute, and test LogScale queries
+- [ ] (optional) Generate mock data to test your app
+
+Deploy it to Foundry:
+
+```shell
+foundry deploy
+```
+
+> [!TIP]
+> If you get an error that the name already exists, change the name to something unique to your CID in `manifest.yml`.
+
+Once the deployment has finished, release the app using the three-dot menu on the right. Next, go to **Foundry** > **App catalog**, find your app, and install it.
+
+Then, open the main menu in the top left and go to **Custom Apps**. You should see your app listed and be able to enter a job. After the job executes, you'll receive an email with the execution information.
+
+## Basic information
 
 ### Foundry capabilities used
 
@@ -93,37 +129,19 @@ Run `foundry version` to verify it's installed correctly.
     * `Check_if_Registry_key_Value_Exist.yml`: Workflow to invoke the `Check_Registry_Exist` RTR script against a collection of hosts.  Results are written to LogScale.
     * `Notify_status.yml`: Workflow which notifies the `job_history` function to report results of the `Check_if_files_or_registry_key_exist` and `Check_if_Registry_key_Value_Exist.yml`.
 
-## Running, deploying and installing the app
+## Running, deploying and installing Custom Apps
 
-For detailed info about running, deploying and installing this app in your CID, see the Falcon Foundry product documentation:
+For detailed info about running, deploying and installing custom apps in your CID, see the Falcon Foundry product documentation:
 
-* Overview and setup
-    * US-1: [Before you begin](https://falcon.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities)
-    * US-2: [Before you begin](https://falcon.us-2.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities)
-    * EU-1: [Before you begin](https://falcon.eu-1.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities)
-* Deploy an app
-    * US-1: [Deploy an app](https://falcon.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app)
-    * US-2: [Deploy an app](https://falcon.us-2.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app)
-    * EU-1: [Deploy an app](https://falcon.eu-1.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app)
-* Create a new app using this app as template
-    * US-1: [Create an app from a template](https://falcon.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86)
-    * US-2: [Create an app from a template](https://falcon.us-2.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86)
-    * EU-1: [Create an app from a template](https://falcon.eu-1.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86)
-* Run this app in development mode after deployment
-    * US-1: [Iterate in development mode](https://falcon.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2)
-    * US-2: [Iterate in development mode](https://falcon.us-2.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2)
-    * EU-1: [Iterate in development mode](https://falcon.eu-1.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2)
-* Work with the Foundry capabilities of this app
-    * US-1: [App capabilities](https://falcon.crowdstrike.com/documentation/category/u0daabab/app-capabilities)
-    * US-2: [App capabilities](https://falcon.us-2.crowdstrike.com/documentation/category/u0daabab/app-capabilities)
-    * EU-1: [App capabilities](https://falcon.eu-1.crowdstrike.com/documentation/category/u0daabab/app-capabilities)
+* Overview and setup: [US](https://falcon.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities), [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities), [EU-1](https://falcon.eu-1.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities)
+* Deploy an app: [US](https://falcon.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app), [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app), [EU-1](https://falcon.eu-1.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app)
+* Create a new app using this app as template: [US](https://falcon.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86), [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86), [EU-1](https://falcon.eu-1.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86)
+* Run an app in development mode after deployment: [US](https://falcon.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2), [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2), [EU-1](https://falcon.eu-1.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2)
+* Work with the Foundry capabilities of an app: [US](https://falcon.crowdstrike.com/documentation/category/u0daabab/app-capabilities), [US-2](https://falcon.us-2.crowdstrike.com/documentation/category/u0daabab/app-capabilities), [EU-1](https://falcon.eu-1.crowdstrike.com/documentation/category/u0daabab/app-capabilities)
 
 ## Foundry resources
 
-See our product documentation:
-* US-1: [Falcon Foundry](https://falcon.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry)
-* US-2: [Falcon Foundry](https://falcon.us-2.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry)
-* EU-1: [Falcon Foundry](https://falcon.eu-1.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry)
+See our product documentation: [US](https://falcon.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry), [US-2](https://falcon.us-2.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry), [EU1](https://falcon.eu-1.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This app is one of several App Templates included in Foundry that you can use to
 preconfigured capabilities aligned to its business purpose. Deploy this app from the Templates page with a single click in the Foundry UI, or 
 create an app from this template using the CLI.
 
-Please complete the Foundry Quickstart before deploying this sample. You can find it in Falcon under **Foundry** > **Learn** ([US-1](https://falcon.crowdstrike.com/foundry/learn), [US-2](https://falcon.us-2.crowdstrike.com/foundry/learn), [EU](https://falcon.eu-1.crowdstrike.com/foundry/learn)). 
+Please complete the Foundry Quickstart before deploying this sample. You can find it in Falcon under **Foundry** > **Learn** ([US-1](https://falcon.crowdstrike.com/foundry/learn) | [US-2](https://falcon.us-2.crowdstrike.com/foundry/learn) | [EU](https://falcon.eu-1.crowdstrike.com/foundry/learn)). 
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -133,11 +133,9 @@ Go to **Custom apps**. You should see your app listed and be able to enter a job
 
 For detailed info about running, deploying and installing custom apps in your CID, see the Falcon Foundry product documentation:
 
-* Overview and setup: [US-1](https://falcon.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities), [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities), [EU](https://falcon.eu-1.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities)
-* Deploy an app: [US-1](https://falcon.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app), [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app), [EU](https://falcon.eu-1.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app)
-* Create a new app using this app as template: [US-1](https://falcon.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86), [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86), [EU](https://falcon.eu-1.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86)
-* Run an app in development mode after deployment: [US-1](https://falcon.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2), [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2), [EU](https://falcon.eu-1.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2)
-* Work with the Foundry capabilities of an app: [US-1](https://falcon.crowdstrike.com/documentation/category/u0daabab/app-capabilities), [US-2](https://falcon.us-2.crowdstrike.com/documentation/category/u0daabab/app-capabilities), [EU](https://falcon.eu-1.crowdstrike.com/documentation/category/u0daabab/app-capabilities)
+* Overview and setup: [US-1](https://falcon.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities) | [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities) | [EU](https://falcon.eu-1.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities)
+* Deploy an app: [US-1](https://falcon.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app) | [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app) | [EU](https://falcon.eu-1.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app)
+* Create a new app using this app as template: [US-1](https://falcon.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86) | [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86) | [EU](https://falcon.eu-1.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86)
 
 ## Foundry resources
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This app illustrates the following functionality amongst other components:
 
 ## Prerequisites
 
-* Foundry CLI (instructions below)
+* The Foundry CLI (instructions below).
 * Go v1.21+ (needed if modifying the app's functions). See https://go.dev/learn for installation instructions.
 * Yarn (needed if modifying the app's UI). See https://yarnpkg.com/getting-started for installation instructions.
 
@@ -108,10 +108,10 @@ Go to **Custom apps**. You should see your app listed and be able to enter a job
     * Go
     * CrowdStrike Foundry Function Go SDK (https://github.com/CrowdStrike/foundry-fn-go)
 * RTR scripts
-    * Powershell
+    * PowerShell
 * UI
     * HTML, CSS
-    * Typescript, React
+    * TypeScript, React
 
 ### Directory structure
 

--- a/README.md
+++ b/README.md
@@ -129,14 +129,6 @@ Go to **Custom apps**. You should see your app listed and be able to enter a job
     * `Check_if_Registry_key_Value_Exist.yml`: Workflow to invoke the `Check_Registry_Exist` RTR script against a collection of hosts.  Results are written to LogScale.
     * `Notify_status.yml`: Workflow which notifies the `job_history` function to report results of the `Check_if_files_or_registry_key_exist` and `Check_if_Registry_key_Value_Exist.yml`.
 
-## Running, deploying and installing Custom Apps
-
-For detailed info about running, deploying and installing custom apps in your CID, see the Falcon Foundry product documentation:
-
-* Overview and setup: [US-1](https://falcon.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities) | [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities) | [EU](https://falcon.eu-1.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities)
-* Deploy an app: [US-1](https://falcon.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app) | [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app) | [EU](https://falcon.eu-1.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app)
-* Create a new app using this app as template: [US-1](https://falcon.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86) | [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86) | [EU](https://falcon.eu-1.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86)
-
 ## Foundry resources
 
 - Foundry documentation: [US-1](https://falcon.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry) | [US-2](https://falcon.us-2.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry) | [EU](https://falcon.eu-1.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This app is one of several App Templates included in Foundry that you can use to
 preconfigured capabilities aligned to its business purpose. Deploy this app from the Templates page with a single click in the Foundry UI, or 
 create an app from this template using the CLI.
 
-Please complete the Foundry Quickstart before deploying this sample. You can find it in Falcon under **Foundry** > **Learn** ([US](https://falcon.crowdstrike.com/foundry/learn), [US-2](https://falcon.us-2.crowdstrike.com/foundry/learn), [EU](https://falcon.eu-1.crowdstrike.com/foundry/learn)). 
+Please complete the Foundry Quickstart before deploying this sample. You can find it in Falcon under **Foundry** > **Learn** ([US-1](https://falcon.crowdstrike.com/foundry/learn), [US-2](https://falcon.us-2.crowdstrike.com/foundry/learn), [EU](https://falcon.eu-1.crowdstrike.com/foundry/learn)). 
 
 ## Description
 
@@ -133,15 +133,15 @@ Then, open the main menu in the top left and go to **Custom Apps**. You should s
 
 For detailed info about running, deploying and installing custom apps in your CID, see the Falcon Foundry product documentation:
 
-* Overview and setup: [US](https://falcon.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities), [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities), [EU-1](https://falcon.eu-1.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities)
-* Deploy an app: [US](https://falcon.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app), [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app), [EU-1](https://falcon.eu-1.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app)
-* Create a new app using this app as template: [US](https://falcon.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86), [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86), [EU-1](https://falcon.eu-1.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86)
-* Run an app in development mode after deployment: [US](https://falcon.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2), [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2), [EU-1](https://falcon.eu-1.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2)
-* Work with the Foundry capabilities of an app: [US](https://falcon.crowdstrike.com/documentation/category/u0daabab/app-capabilities), [US-2](https://falcon.us-2.crowdstrike.com/documentation/category/u0daabab/app-capabilities), [EU-1](https://falcon.eu-1.crowdstrike.com/documentation/category/u0daabab/app-capabilities)
+* Overview and setup: [US-1](https://falcon.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities), [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities), [EU](https://falcon.eu-1.crowdstrike.com/documentation/page/f5f7cd69/falcon-console-user-interface-capabilities)
+* Deploy an app: [US-1](https://falcon.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app), [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app), [EU](https://falcon.eu-1.crowdstrike.com/documentation/page/ofd46a1c/deploy-an-app)
+* Create a new app using this app as template: [US-1](https://falcon.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86), [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86), [EU](https://falcon.eu-1.crowdstrike.com/documentation/page/l159717b/create-an-app#c4378b86)
+* Run an app in development mode after deployment: [US-1](https://falcon.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2), [US-2](https://falcon.us-2.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2), [EU](https://falcon.eu-1.crowdstrike.com/documentation/page/fb88e442/view-and-manage-apps#d5175ae2)
+* Work with the Foundry capabilities of an app: [US-1](https://falcon.crowdstrike.com/documentation/category/u0daabab/app-capabilities), [US-2](https://falcon.us-2.crowdstrike.com/documentation/category/u0daabab/app-capabilities), [EU](https://falcon.eu-1.crowdstrike.com/documentation/category/u0daabab/app-capabilities)
 
 ## Foundry resources
 
-See our product documentation: [US](https://falcon.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry), [US-2](https://falcon.us-2.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry), [EU1](https://falcon.eu-1.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry)
+See our product documentation: [US-1](https://falcon.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry), [US-2](https://falcon.us-2.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry), [EU1](https://falcon.eu-1.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,18 @@ foundry apps deploy
 > [!TIP]
 > If you get an error that the name already exists, change the name to something unique to your CID in `manifest.yml`.
 
-Once the deployment has finished, release the app using the three-dot menu on the right. Next, go to **Foundry** > **App catalog**, find your app, and install it.
+Once the deployment has finished, you can release the app:
 
-Go to **Custom apps**. You should see your app listed and be able to enter a job. After the job executes, you'll receive an email with the execution information.
+```shell
+foundry apps release
+```
+
+Next, go to **Foundry** > **App catalog**, find your app, and install it. Select the **Open App** button in the success dialog.
+
+> [!TIP]
+> If the app doesn't load, reload the page.
+
+You should be able to enter a job. After the job executes, you'll receive an email with the execution information.
 
 ## About this sample app
 

--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ Go to **Custom apps**. You should see your app listed and be able to enter a job
 
 ### Foundry capabilities used
 
-* **Collections.**  Used by the app to store state information, such as metadata about created jobs, execution history, and an audit log.
-* **Functions.**  Backend business logic for invoking workflows, normalizing and aggregating data to be returned to the UI, and modifying the state of the collections.
-* **LogScale queries.**  Query results of RTR script execution from LogScale to extract metadata about on which hosts the scripts successfully executed.
-* **RTR scripts.**  Verifies files and registry keys on a target system.
-* **UI navigation.**  Adds the app to the Falcon navigation for easy access.
-* **UI pages.**  Custom UI pages to display results and manage the app.
-* **Workflow templates.**  Workflows for orchestrating the execution of the jobs against individual hosts and host groups.
+* **Collections.** Used by the app to store state information, such as metadata about created jobs, execution history, and an audit log.
+* **Functions.** Backend business logic for invoking workflows, normalizing and aggregating data to be returned to the UI, and modifying the state of the collections.
+* **LogScale queries.** Query results of RTR script execution from LogScale to extract metadata about on which hosts the scripts successfully executed.
+* **RTR scripts.** Verifies files and registry keys on a target system.
+* **UI navigation.** Adds the app to the Falcon navigation for easy access.
+* **UI pages.** Custom UI pages to display results and manage the app.
+* **Workflow templates.** Workflows for orchestrating the execution of the jobs against individual hosts and host groups.
 
 ### Languages and frameworks used
 
@@ -115,18 +115,18 @@ Go to **Custom apps**. You should see your app listed and be able to enter a job
 
 ### Directory structure
 
-* `collections`.  Schemas used in the collections used by this app.
+* `collections`. Schemas used in the collections used by this app.
 * `functions`
-    * `Func_Jobs`:  Creates and updates jobs, invokes workflows, and manages the audit log.
-    * `job_history`:  Manages the job execution history.
+    * `Func_Jobs`: Creates and updates jobs, invokes workflows, and manages the audit log.
+    * `job_history`: Manages the job execution history.
 * `rtr-scripts`
-    * `check_file_or_registry_exist`:  RTR script which checks if a file or registry key is present on a Windows system.
-    * `Check_Registry_Exist`:  RTR script which checks if a registry key with a specific value is present on Windows system.
-* `saved-searches/Query_By_WorkflowRootExecutionID`:  LogScale saved search for retrieving events by a workflow execution ID.
-* `ui/pages/scalable-rtr-react`:  Single Page Application which serves as the frontend of the app.
-* `workflows`: Workflow template definitions.  Fusion workflows are created from the templates in this directory.
+    * `check_file_or_registry_exist`: RTR script which checks if a file or registry key is present on a Windows system.
+    * `Check_Registry_Exist`: RTR script which checks if a registry key with a specific value is present on Windows system.
+* `saved-searches/Query_By_WorkflowRootExecutionID`: LogScale saved search for retrieving events by a workflow execution ID.
+* `ui/pages/scalable-rtr-react`: Single Page Application which serves as the frontend of the app.
+* `workflows`: Workflow template definitions. Fusion workflows are created from the templates in this directory.
     * `Check_if_files_or_registry_key_exist.yml`: Workflow to invoke the `check_file_or_registry_exist` RTR script against a collection of hosts. Results are written to LogScale.
-    * `Check_if_Registry_key_Value_Exist.yml`: Workflow to invoke the `Check_Registry_Exist` RTR script against a collection of hosts.  Results are written to LogScale.
+    * `Check_if_Registry_key_Value_Exist.yml`: Workflow to invoke the `Check_Registry_Exist` RTR script against a collection of hosts. Results are written to LogScale.
     * `Notify_status.yml`: Workflow which notifies the `job_history` function to report results of the `Check_if_files_or_registry_key_exist` and `Check_if_Registry_key_Value_Exist.yml`.
 
 ## Foundry resources

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Once the deployment has finished, release the app using the three-dot menu on th
 
 Go to **Custom apps**. You should see your app listed and be able to enter a job. After the job executes, you'll receive an email with the execution information.
 
-## Basic information
+## About this sample app
 
 ### Foundry capabilities used
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ For detailed info about running, deploying and installing custom apps in your CI
 ## Foundry resources
 
 - Foundry documentation: [US-1](https://falcon.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry) | [US-2](https://falcon.us-2.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry) | [EU](https://falcon.eu-1.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry)
-Foundry learning resources: [US-1](https://falcon.crowdstrike.com/foundry/learn) | [US-2](https://falcon.us-2.crowdstrike.com/foundry/learn) | [EU](https://falcon.eu-1.crowdstrike.com/foundry/learn)
+- Foundry learning resources: [US-1](https://falcon.crowdstrike.com/foundry/learn) | [US-2](https://falcon.us-2.crowdstrike.com/foundry/learn) | [EU](https://falcon.eu-1.crowdstrike.com/foundry/learn)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Select the following permissions:
 - [x] Run, execute, and test LogScale queries
 - [ ] (optional) Generate mock data to test your app
 
-Deploy it to Foundry:
+Deploy the app to Foundry:
 
 ```shell
 foundry apps deploy

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ For detailed info about running, deploying and installing custom apps in your CI
 
 ## Foundry resources
 
-See our product documentation: [US-1](https://falcon.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry), [US-2](https://falcon.us-2.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry), [EU1](https://falcon.eu-1.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry)
+- Foundry documentation: [US-1](https://falcon.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry) | [US-2](https://falcon.us-2.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry) | [EU](https://falcon.eu-1.crowdstrike.com/documentation/category/c3d64B8e/falcon-foundry)
+Foundry learning resources: [US-1](https://falcon.crowdstrike.com/foundry/learn) | [US-2](https://falcon.us-2.crowdstrike.com/foundry/learn) | [EU](https://falcon.eu-1.crowdstrike.com/foundry/learn)
 
 ---
 


### PR DESCRIPTION
- Add a Getting Started section that describes how to clone, deploy, and install
- Make links more compact at the bottom