### PR TITLE
chore: upgrade to latest go fdk

### DIFF
--- a/functions/Func_Jobs/go.mod
+++ b/functions/Func_Jobs/go.mod
@@ -3,7 +3,7 @@ module github.com/Crowdstrike/foundry-sample-scalable-rtr/functions/Func_Jobs
 go 1.21
 
 require (
-	github.com/CrowdStrike/foundry-fn-go v0.23.1
+	github.com/CrowdStrike/foundry-fn-go v0.23.2
 	github.com/crowdstrike/gofalcon v0.4.3-0.20231013182855-e96a02e115d9
 	github.com/go-openapi/runtime v0.26.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/functions/job_history/go.mod
+++ b/functions/job_history/go.mod
@@ -3,7 +3,7 @@ module github.com/Crowdstrike/foundry-sample-scalable-rtr/functions/job_history
 go 1.21
 
 require (
-	github.com/CrowdStrike/foundry-fn-go v0.23.1
+	github.com/CrowdStrike/foundry-fn-go v0.23.2
 	github.com/crowdstrike/gofalcon v0.5.0-rc1.0.20231018211136-aa9a14d480c8
 	github.com/eapache/go-resiliency v1.4.0
 	github.com/robfig/cron/v3 v3.0.1


### PR DESCRIPTION
[foundry-fn-go release notes](https://github.com/CrowdStrike/foundry-fn-go/releases/tag/v0.23.2)