### PR TITLE
Increase dependabot open-pull-requests-limit to 15

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/ui/pages/scalable-rtr-react/"
+    open-pull-requests-limit: 15
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"


### PR DESCRIPTION
## Summary
Increases the dependabot `open-pull-requests-limit` from the default 5 to 15 for the npm package ecosystem.

## Motivation
- Dependabot was hitting the default limit of 5 PRs and stopping further updates
- With many dependencies to update, we need higher concurrency to keep packages current
- This prevents dependency updates from being delayed due to PR limits

## Changes
- Updated `.github/dependabot.yml` to set `open-pull-requests-limit: 15` for npm dependencies
- No functional changes to dependency update behavior, just allows more concurrent PRs

This will allow dependabot to create more PRs when needed, ensuring all available dependency updates can be processed.