### PR TITLE
Schedule dependabot runs for Monday 8am MT

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,22 @@ updates:
     directory: "/ui/pages/scalable-rtr-react/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "14:00"
+      timezone: "UTC"
   - package-ecosystem: "gomod"
     directories:
       - "/functions/Func_Jobs/"
       - "/functions/job_history/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "14:00"
+      timezone: "UTC"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "14:00"
+      timezone: "UTC"


### PR DESCRIPTION
Configure dependabot to run every Monday at 8am Mountain Time (14:00 UTC) for consistent weekly dependency updates.