### PR TITLE
Fix null body crash on all pages and tighten e2e assertions

### DIFF
--- a/e2e/src/pages/AllJobsPage.ts
+++ b/e2e/src/pages/AllJobsPage.ts
@@ -19,8 +19,7 @@ export class AllJobsPage extends BasePage {
     // The app content is in an iframe
     const frame = this.page.frameLocator('iframe[name="portal"]').first();
 
-    // Look for Create Job button or job list container
-    const createJobButton = frame.locator('button', { hasText: /create job/i });
+    const createJobButton = frame.locator('a', { hasText: /create job/i });
     const jobsContainer = frame.locator('[class*="job"]').or(frame.locator('table'));
 
     if (
@@ -39,10 +38,9 @@ export class AllJobsPage extends BasePage {
   async hasCreateJobButton(): Promise<boolean> {
     this.logger.step('Check for Create Job button');
 
-    // The app content is in an iframe
     const frame = this.page.frameLocator('iframe[name="portal"]').first();
-    const createJobButton = frame.locator('button', { hasText: /create job/i });
-    const exists = await this.elementExists(createJobButton, 3000);
+    const createJobButton = frame.locator('a', { hasText: /create job/i });
+    const exists = await this.elementExists(createJobButton, 10000);
 
     this.logger.info(`Create Job button ${exists ? 'found' : 'not found'}`);
     return exists;
@@ -54,9 +52,8 @@ export class AllJobsPage extends BasePage {
   async clickCreateJob(): Promise<void> {
     this.logger.step('Click Create Job button');
 
-    // The app content is in an iframe
     const frame = this.page.frameLocator('iframe[name="portal"]').first();
-    const createJobButton = frame.locator('button', { hasText: /create job/i });
+    const createJobButton = frame.locator('a', { hasText: /create job/i });
     await createJobButton.click();
     await this.waiter.delay(1000);
 
@@ -84,13 +81,13 @@ export class AllJobsPage extends BasePage {
   async verifyPageRenders(): Promise<boolean> {
     this.logger.step('Verify All Jobs page renders');
 
-    // Check for main page elements
+    const frame = this.page.frameLocator('iframe[name="portal"]').first();
+    const heading = frame.locator('h1', { hasText: /all jobs/i });
+    const hasHeading = await this.elementExists(heading, 10000);
     const hasButton = await this.hasCreateJobButton();
-    const url = this.getCurrentUrl();
-    const hasCorrectUrl = url.includes('all-jobs') || url.includes('path=%2F');
 
-    const renders = hasButton || hasCorrectUrl;
-    this.logger.info(`All Jobs page renders: ${renders}`);
+    const renders = hasHeading && hasButton;
+    this.logger.info(`All Jobs page renders: ${renders} (heading: ${hasHeading}, button: ${hasButton})`);
 
     return renders;
   }

--- a/e2e/src/pages/AuditLogPage.ts
+++ b/e2e/src/pages/AuditLogPage.ts
@@ -69,12 +69,18 @@ export class AuditLogPage extends BasePage {
   async verifyPageRenders(): Promise<boolean> {
     this.logger.step('Verify Audit Log page renders');
 
-    // Check for presence of "Audit log" tab being active or visible content
     const frame = this.page.frameLocator('iframe[name="portal"]').first();
-    const auditLogText = frame.locator('text="Audit log"');
-    const hasContent = await this.elementExists(auditLogText, 3000);
+    const heading = frame.locator('h1', { hasText: /audit log/i });
+    const hasHeading = await this.elementExists(heading, 10000);
 
-    this.logger.info(`Audit Log page renders: ${hasContent}`);
-    return hasContent;
+    if (!hasHeading) {
+      const table = frame.locator('table');
+      const hasTable = await this.elementExists(table, 3000);
+      this.logger.info(`Audit Log page renders: ${hasTable} (table fallback)`);
+      return hasTable;
+    }
+
+    this.logger.info(`Audit Log page renders: ${hasHeading}`);
+    return hasHeading;
   }
 }

--- a/e2e/src/pages/RunHistoryPage.ts
+++ b/e2e/src/pages/RunHistoryPage.ts
@@ -69,12 +69,18 @@ export class RunHistoryPage extends BasePage {
   async verifyPageRenders(): Promise<boolean> {
     this.logger.step('Verify Run History page renders');
 
-    // Check for presence of "Run history" tab being active or visible content
     const frame = this.page.frameLocator('iframe[name="portal"]').first();
-    const runHistoryText = frame.locator('text="Run history"');
-    const hasContent = await this.elementExists(runHistoryText, 3000);
+    const heading = frame.locator('h1', { hasText: /run history/i });
+    const hasHeading = await this.elementExists(heading, 10000);
 
-    this.logger.info(`Run History page renders: ${hasContent}`);
-    return hasContent;
+    if (!hasHeading) {
+      const table = frame.locator('table');
+      const hasTable = await this.elementExists(table, 3000);
+      this.logger.info(`Run History page renders: ${hasTable} (table fallback)`);
+      return hasTable;
+    }
+
+    this.logger.info(`Run History page renders: ${hasHeading}`);
+    return hasHeading;
   }
 }

--- a/e2e/tests/foundry.spec.ts
+++ b/e2e/tests/foundry.spec.ts
@@ -110,18 +110,13 @@ test.describe('Scalable RTR App E2E Tests', () => {
     await scalableRTRHomePage.navigateToAllJobs();
 
     const hasButton = await allJobsPage.hasCreateJobButton();
+    expect(hasButton).toBeTruthy();
 
-    if (hasButton) {
-      await allJobsPage.clickCreateJob();
-      await allJobsPage.waiter.delay(1000);
+    await allJobsPage.clickCreateJob();
+    await allJobsPage.waiter.delay(1000);
 
-      const url = allJobsPage.getCurrentUrl();
-      const hasCreateJobUrl = url.includes('create-job');
-      console.log(`Create Job form accessible: ${hasCreateJobUrl}`);
-      expect(hasButton).toBeTruthy();
-    } else {
-      console.log('ℹ️  Create Job button not found (may be permission-based)');
-    }
+    const url = allJobsPage.getCurrentUrl();
+    expect(url).toContain('create-job');
 
     console.log('✅ Create Job button accessibility verified');
   });

--- a/ui/pages/scalable-rtr-react/src/lib/validations/api-validation.ts
+++ b/ui/pages/scalable-rtr-react/src/lib/validations/api-validation.ts
@@ -218,13 +218,15 @@ export const MetaSchema = z.object({
 });
 
 export const allJobsDataSchema = z.object({
-  body: z.object({
-    resources: z
-      .array(JobSchema)
-      .nullable()
-      .transform((val) => val ?? []),
-    meta: MetaSchema,
-  }),
+  body: z
+    .object({
+      resources: z
+        .array(JobSchema)
+        .nullable()
+        .transform((val) => val ?? []),
+      meta: MetaSchema,
+    })
+    .nullable(),
 });
 
 export const jobDataSchema = z.object({
@@ -250,13 +252,15 @@ export const RunHistorySchema = z.object({
 export type RunHistory = z.infer<typeof RunHistorySchema>;
 
 export const runHistoryDataSchema = z.object({
-  body: z.object({
-    resources: z
-      .array(RunHistorySchema)
-      .nullable()
-      .transform((val) => val ?? []),
-    meta: MetaSchema,
-  }),
+  body: z
+    .object({
+      resources: z
+        .array(RunHistorySchema)
+        .nullable()
+        .transform((val) => val ?? []),
+      meta: MetaSchema,
+    })
+    .nullable(),
 });
 
 export const AuditLogSchema = z.object({
@@ -272,13 +276,15 @@ export const AuditLogSchema = z.object({
 export type AuditLog = z.infer<typeof AuditLogSchema>;
 
 export const auditLogDataSchema = z.object({
-  body: z.object({
-    resources: z
-      .array(AuditLogSchema)
-      .nullable()
-      .transform((val) => val ?? []),
-    meta: MetaSchema,
-  }),
+  body: z
+    .object({
+      resources: z
+        .array(AuditLogSchema)
+        .nullable()
+        .transform((val) => val ?? []),
+      meta: MetaSchema,
+    })
+    .nullable(),
 });
 
 export const historyJobsAuditLogSchema = z.object({

--- a/ui/pages/scalable-rtr-react/src/pages/AllJobs.tsx
+++ b/ui/pages/scalable-rtr-react/src/pages/AllJobs.tsx
@@ -50,9 +50,11 @@ export const loader: Loader = ({ falcon }) => {
     });
     const safeResult = allJobsDataSchema.parse(result);
 
-    safeResult.body.meta.offset = safeResult.body.resources?.[0]?.id ?? "";
-    // Add a computed page number to render the pagination data
-    safeResult.body.meta.page = page;
+    if (safeResult.body) {
+      safeResult.body.meta.offset = safeResult.body.resources?.[0]?.id ?? "";
+      // Add a computed page number to render the pagination data
+      safeResult.body.meta.page = page;
+    }
 
     return safeResult;
   };
@@ -98,7 +100,11 @@ function AllJobs() {
     }
   }, [location.state]);
 
-  if (data.body.meta.total === 0) {
+  if (data.body?.meta.total === 0) {
+    return <NoJobs />;
+  }
+
+  if (!data.body) {
     return <NoJobs />;
   }
 

--- a/ui/pages/scalable-rtr-react/src/pages/AuditLog.tsx
+++ b/ui/pages/scalable-rtr-react/src/pages/AuditLog.tsx
@@ -39,9 +39,11 @@ export const loader: Loader = ({ falcon }) => {
     });
     const result = auditLogDataSchema.parse(rawResult);
 
-    result.body.meta.offset = result.body.resources?.[0]?.id ?? "";
-    // Add a computed page number to render the pagination data
-    result.body.meta.page = page;
+    if (result.body) {
+      result.body.meta.offset = result.body.resources?.[0]?.id ?? "";
+      // Add a computed page number to render the pagination data
+      result.body.meta.page = page;
+    }
 
     return result;
   };
@@ -50,7 +52,11 @@ export const loader: Loader = ({ falcon }) => {
 function AuditLog() {
   const data = useParsedLoaderData<AuditLogDataSchema>(auditLogDataSchema);
 
-  if (data.body.meta.total === 0) {
+  if (data.body?.meta.total === 0) {
+    return <NoAuditLogs />;
+  }
+
+  if (!data.body) {
     return <NoAuditLogs />;
   }
 

--- a/ui/pages/scalable-rtr-react/src/pages/JobDetails.tsx
+++ b/ui/pages/scalable-rtr-react/src/pages/JobDetails.tsx
@@ -78,21 +78,21 @@ function JobDetails() {
   );
   const historyTableData = useMemo(
     () =>
-      mapJobHistoryDetailsToTableData(data.history.body.resources, {
+      mapJobHistoryDetailsToTableData(data.history.body?.resources ?? [], {
         timezone,
         locale,
         dateFormat,
       }),
-    [data.history.body.resources, timezone, locale, dateFormat],
+    [data.history.body?.resources, timezone, locale, dateFormat],
   );
   const auditLogTableData = useMemo(
     () =>
-      mapAuditLogDetailsToTableData(data.auditLogs.body.resources, {
+      mapAuditLogDetailsToTableData(data.auditLogs.body?.resources ?? [], {
         timezone,
         locale,
         dateFormat,
       }),
-    [data.auditLogs.body.resources, timezone, locale, dateFormat],
+    [data.auditLogs.body?.resources, timezone, locale, dateFormat],
   );
 
   return (

--- a/ui/pages/scalable-rtr-react/src/pages/RunHistory.tsx
+++ b/ui/pages/scalable-rtr-react/src/pages/RunHistory.tsx
@@ -51,10 +51,12 @@ export const loader: Loader = ({ falcon }) => {
     });
     const safeResult = runHistoryDataSchema.parse(result);
 
-    safeResult.body.meta.offset =
-      safeResult.body.resources?.[0]?.execution_id ?? "";
-    // Add a computed page number to render the pagination information
-    safeResult.body.meta.page = page;
+    if (safeResult.body) {
+      safeResult.body.meta.offset =
+        safeResult.body.resources?.[0]?.execution_id ?? "";
+      // Add a computed page number to render the pagination information
+      safeResult.body.meta.page = page;
+    }
 
     return safeResult;
   };
@@ -71,7 +73,11 @@ function RunHistory() {
    */
   const [activeHostsOnDrawer, setActiveHostsForDrawer] = useState<string[]>([]);
 
-  if (data.body.meta.total === 0 && !hasActiveFilters) {
+  if (data.body?.meta.total === 0 && !hasActiveFilters) {
+    return <NoRuns />;
+  }
+
+  if (!data.body) {
     return <NoRuns />;
   }
 


### PR DESCRIPTION
All three main pages (All Jobs, Run History, Audit Log) crash with "An error has happened" when cloud functions return responses without a `body` field (e.g., when no jobs exist). The Zod schemas required a non-nullable `body`, so `.parse()` throws a ZodError when `body` is null. This adds `.nullable()` to `allJobsDataSchema`, `runHistoryDataSchema`, and `auditLogDataSchema`, adds null checks in the route loaders and components, and uses optional chaining in `JobDetails.tsx`.

Also tightens e2e test assertions and fixes the Create Job selector to use `a` (it's a React Router Link, not a button).

Fixes #344